### PR TITLE
Fix bug with incrementing after deleted END rules

### DIFF
--- a/packages/gbnf/src/grammar-parser/grammar-parser.test.ts
+++ b/packages/gbnf/src/grammar-parser/grammar-parser.test.ts
@@ -377,6 +377,14 @@ describe('GrammarParser', () => {
         { type: RuleType.RANGE, value: [['a'.charCodeAt(0), 'z'.charCodeAt(0)], ['A'.charCodeAt(0), 'Z'.charCodeAt(0)]], },
         { type: RuleType.END, },
       ]],
+
+      // real world bugs
+      [
+        'root ::= "foo" | "bar" | "baz" | "bazaar" | "barrington" ',
+        'bazaa', [
+          { type: RuleType.CHAR, value: 'r'.charCodeAt(0), },
+        ]
+      ],
     ])('it parses a grammar `%s` against input: `%s`', (grammar, input, expected) => {
       const Parser = GBNF(grammar.split('\\n').join('\n'));
       const parser = new Parser(input);
@@ -466,18 +474,6 @@ describe('GrammarParser', () => {
       const parser = new Parser(starting);
       expect(() => parser.add(additional)).toThrow();
     });
-
-
-
-
-
-
-
-
-
-
-
-
 
     test.each([
       // single char rule
@@ -656,6 +652,12 @@ describe('GrammarParser', () => {
         { type: RuleType.RANGE, value: [['a'.charCodeAt(0), 'z'.charCodeAt(0)], ['A'.charCodeAt(0), 'Z'.charCodeAt(0)]], },
         { type: RuleType.END, },
       ]],
+      [
+        'root ::= "foo" | "bar" | "baz" | "bazaar" | "barrington" ',
+        'baza', 'a', [
+          { type: RuleType.CHAR, value: 'r'.charCodeAt(0), },
+        ]
+      ],
     ])('it parses a grammar `%s` with starting `%s` and additional `%s`', (grammar, starting, additional, expected) => {
       const Parser = GBNF(grammar.split('\\n').join('\n'));
       const parser = new Parser(starting);

--- a/packages/gbnf/src/grammar-parser/grammar-parser.ts
+++ b/packages/gbnf/src/grammar-parser/grammar-parser.ts
@@ -53,6 +53,8 @@ export const getGrammarParser = (ruleDefs: RuleDef[][], symbolIds: SymbolIds) =>
     public add = (src: string) => {
       let strPos = 0;
       this.start = performance.now();
+      console.log('path "baz"', this.stacks[0][0]);
+      console.log('path "bazaar"', this.stacks[0][1]);
       const updateRulePointers = (_pointer: RulePointer, depth = 0): RulePointer => {
         let rulePointerIdx = 0;
         while (rulePointerIdx < _pointer.length) {
@@ -63,11 +65,17 @@ export const getGrammarParser = (ruleDefs: RuleDef[][], symbolIds: SymbolIds) =>
             rulePointerIdx++;
           } else {
             const { stackPos, pathPos, rulePos, } = pointer;
+            // if (rulePos >= 3) { // second z
+            //   console.log('pointer', pointer);
+            // }
             const rule = this.stacks[stackPos][pathPos][rulePos];
             if (rule === undefined) {
               throw new Error('Out of bounds rule');
             }
             const char = src[strPos];
+            if (rulePos >= 0) {
+              console.log(`char (${char}) rule (${rulePos}) for path`, pointer.pathPos, 'is', rule);
+            }
             if (rule.type === RuleType.CHAR) {
               const ruleChar = String.fromCharCode(rule.value);
               const valid = char === ruleChar;
@@ -113,12 +121,12 @@ export const getGrammarParser = (ruleDefs: RuleDef[][], symbolIds: SymbolIds) =>
                   pathPos,
                   rulePos: rulePos + 1,
                 };
+                rulePointerIdx++;
               } else {
                 // reached the end of this path, remove it
                 _pointer = _pointer.filter((_, i) => i !== rulePointerIdx);
               }
 
-              rulePointerIdx++;
             } else {
               throw new Error(`Unsupported rule type: ${rule.type}`);
             }
@@ -131,8 +139,10 @@ export const getGrammarParser = (ruleDefs: RuleDef[][], symbolIds: SymbolIds) =>
           throw new Error('Invalid input string, cannot be parsed');
         }
         this.rulePointer = updateRulePointers(this.rulePointer);
+        console.log(this.rulePointer);
         strPos++;
       }
+      // console.log(this.rulePointer[0], this.stacks[0][1]);
 
       if (this.hasValidRules === false) {
         throw new Error('Invalid input string, cannot be parsed');


### PR DESCRIPTION
Fixes bug where, after deleting a possible parsing path (eaching an END) rule, the rule pointer was incorrectly incremented, affecting the pathways of other words.

This manifested when parsing a grammar such as:

```
root ::= "bar" | "bazaar"
```