### PR TITLE
Refactor Stacks

### DIFF
--- a/packages/gbnf/src/grammar-parser/grammar-parser.ts
+++ b/packages/gbnf/src/grammar-parser/grammar-parser.ts
@@ -17,11 +17,6 @@ export const getGrammarParser = (ruleDefs: Rule[][], symbolIds: SymbolIds) => {
     constructor(src: string) {
       const rootId = this.symbolIds.get('root');
       this.rulePointer = new RulePointer(this.stacks, rootId);
-      // for (const rules of this.ruleDefs) {
-      //   for (const rule of rules) {
-      //     this.ruleSet.add(rule);
-      //   }
-      // }
       this.add(src);
     }
 


### PR DESCRIPTION
Wrap Stacks into a class, so that we can identify
unique rules while still exposing (largely) the same API