### PR TITLE
Refactor graph node instantiation

### DIFF
--- a/packages/gbnf/src/grammar-parser/graph/graph-node.ts
+++ b/packages/gbnf/src/grammar-parser/graph/graph-node.ts
@@ -1,5 +1,4 @@
 import { Color, } from "./colorize.js";
-import type { Graph, } from "./graph.js";
 import { isRuleChar, isRuleRange, isRuleRef, type PrintOpts, type GraphRule, } from "./types.js";
 
 const rules = new Map<GraphRule, number>();
@@ -11,22 +10,22 @@ const getUniqueId = (rule: GraphRule) => {
     return id;
   }
 };
-export class GraphNode {
-  rule: GraphRule;
-  _next = new Map<number, GraphNode>();
+
+interface GraphNodeMeta {
   stackId: number;
   pathId: number;
   stepId: number;
-  graph: Graph;
-  constructor(graph: Graph, stack: GraphRule[][], stackId: number, pathId: number, stepId: number) {
-    this.graph = graph;
-    this.stackId = stackId;
-    this.pathId = pathId;
-    this.stepId = stepId;
-    this.rule = stack[pathId][stepId];
+}
+export class GraphNode {
+  rule: GraphRule;
+  _next = new Map<number, GraphNode>();
+  meta: GraphNodeMeta;
+  constructor(stack: GraphRule[][], meta: GraphNodeMeta) {
+    this.meta = meta;
+    this.rule = stack[meta.pathId][meta.stepId];
 
-    if (stack[pathId][stepId + 1]) {
-      this._next.set(pathId, new GraphNode(graph, stack, stackId, pathId, stepId + 1));
+    if (stack[meta.pathId][meta.stepId + 1]) {
+      this._next.set(meta.pathId, new GraphNode(stack, { ...meta, stepId: meta.stepId + 1, }));
     }
   }
 
@@ -42,7 +41,7 @@ export class GraphNode {
     if (showPosition) {
       parts.push(
         col('{', Color.BLUE),
-        col(`${[this.stepId,].join('-')}`, Color.GRAY),
+        col(`${[this.meta.stepId,].join('-')}`, Color.GRAY),
         col('}', Color.BLUE),
       );
     }

--- a/packages/gbnf/src/grammar-parser/graph/graph-pointer.ts
+++ b/packages/gbnf/src/grammar-parser/graph/graph-pointer.ts
@@ -65,7 +65,7 @@ const getParentStackId = (pointer: GraphPointer, col: Colorize): string => {
   const stackIds: string[] = [];
   let parent: undefined | GraphPointer = pointer.parent;
   while (parent) {
-    const { node: { stackId, pathId, stepId, }, } = parent;
+    const { node: { meta: { stackId, pathId, stepId, }, }, } = parent;
     // stackIds.push(`${parent.node.stackId}`);
     stackIds.push(`${stackId},${pathId},${stepId}`);
     parent = parent.parent;

--- a/packages/gbnf/src/grammar-parser/graph/graph-pointers-store.ts
+++ b/packages/gbnf/src/grammar-parser/graph/graph-pointers-store.ts
@@ -45,9 +45,11 @@ export class GraphPointersStore {
 const getPointerKey = ({
   node: {
     id,
-    stackId,
-    pathId,
-    stepId,
+    meta: {
+      stackId,
+      pathId,
+      stepId,
+    },
   },
   parent,
 }: GraphPointer): string => JSON.stringify({

--- a/packages/gbnf/src/grammar-parser/graph/graph.ts
+++ b/packages/gbnf/src/grammar-parser/graph/graph.ts
@@ -19,7 +19,7 @@ export class Graph {
       const stack = stackedRules[stackId];
       const nodes = new Map<number, GraphNode>();
       for (let pathId = 0; pathId < stack.length; pathId++) {
-        nodes.set(pathId, new GraphNode(this, stack, stackId, pathId, 0));
+        nodes.set(pathId, new GraphNode(stack, { stackId, pathId, stepId: 0, }));
       }
       this.roots.set(stackId, nodes);
     }


### PR DESCRIPTION
No need to reference `graph`, and move identifying information into a `meta` object