### PR TITLE
Refactor graph to separate out pointer args

### DIFF
--- a/packages/gbnf/src/gbnf.ts
+++ b/packages/gbnf/src/gbnf.ts
@@ -16,6 +16,7 @@ export const GBNF = (grammar: string, initialString = '') => {
 
   const stackedRules: GraphRule[][][] = rules.map(buildRuleStack);
   const graph = new Graph(stackedRules, rootId);
+  graph.getInitialPointers();
   graph.add(initialString);
   return graph.state();
 };

--- a/packages/gbnf/src/grammar-parser/graph/graph.ts
+++ b/packages/gbnf/src/grammar-parser/graph/graph.ts
@@ -4,17 +4,18 @@ import { GraphNode, } from "./graph-node.js";
 import { getSerializedRuleKey, } from "./get-serialized-rule-key.js";
 import { colorize, } from "./colorize.js";
 import { GenericSet, } from "./generic-set.js";
-import { GraphRule, Rule, isRange, isRuleChar, isRuleCharExcluded, isRuleEnd, isRuleRef, } from "./types.js";
+import { GraphRule, Pointers, Rule, isRange, isRuleChar, isRuleCharExcluded, isRuleEnd, isRuleRef, } from "./types.js";
 import { isPointInRange, } from "../is-point-in-range.js";
 import { InputParseError, } from "../errors.js";
 import { RuleRef, } from "./rule-ref.js";
 import { State, } from "./state.js";
 
 const customInspectSymbol = Symbol.for('nodejs.util.inspect.custom');
-type Pointers = Set<PublicGraphPointer>;
+type RootNode = Map<number, GraphNode>;
 export class Graph {
-  roots = new Map<number, Map<number, GraphNode>>();
-
+  roots = new Map<number, RootNode>();
+  rootId: number;
+  rootNode: RootNode;
   pointers: Pointers = new Set();
 
   constructor(stackedRules: GraphRule[][][], rootId: number) {
@@ -38,23 +39,28 @@ export class Graph {
 
       this.roots.set(stackId, nodes);
     }
+    this.rootNode = this.roots.get(rootId);
 
     for (const ruleRef of ruleRefs) {
       const referencedNodes = new Set<GraphNode>();
       for (const node of this.roots.get(ruleRef.value).values()) {
-        // for (const { node, } of this.fetchNodesForRootNode(this.roots.get(ruleRef.value))) {
         referencedNodes.add(node);
-        // }
       }
       ruleRef.nodes = referencedNodes;
     }
+  }
 
-    const rootNode = this.roots.get(rootId);
+  getInitialPointers = (): Pointers => {
+    const pointers: Pointers = new Set();
 
-    for (const { node, parent, } of this.fetchNodesForRootNode(rootNode)) {
+    for (const { node, parent, } of this.fetchNodesForRootNode(this.rootNode)) {
       const pointer = new GraphPointer(node, parent);
-      this.addPointer(pointer);
+      for (const resolvedPointer of this.resolvePointer(pointer)) {
+        pointers.add(resolvedPointer);
+      }
     }
+    this.pointers = pointers;
+    return pointers;
   }
 
   setValid(pointers: GraphPointer[], valid: boolean) {
@@ -94,22 +100,24 @@ export class Graph {
 
     const remainingPointers = [...this.pointers,];
     this.pointers = new Set<PublicGraphPointer>();
-    for (const pointer of remainingPointers) {
-      for (const nextPointer of pointer.fetchNext()) {
-        this.addPointer(nextPointer);
+    for (const currentPointer of remainingPointers) {
+      for (const unresolvedNextPointer of currentPointer.fetchNext()) {
+        for (const resolvedNextPointer of this.resolvePointer(unresolvedNextPointer)) {
+          this.pointers.add(resolvedNextPointer);
+        }
       }
     }
   }
 
-  addPointer(unresolvedPointer: GraphPointer) {
-    for (const pointer of unresolvedPointer.resolve()) {
-      if (isRuleRef(pointer.node.rule)) {
+  * resolvePointer(unresolvedPointer: GraphPointer): IterableIterator<PublicGraphPointer> {
+    for (const resolvedPointer of unresolvedPointer.resolve()) {
+      if (isRuleRef(resolvedPointer.node.rule)) {
         throw new Error('Encountered a reference rule when building pointers to the graph');
       }
-      if (isRuleEnd(pointer.node.rule) && !!pointer.parent) {
+      if (isRuleEnd(resolvedPointer.node.rule) && !!resolvedPointer.parent) {
         throw new Error('Encountered an ending rule with a parent when building pointers to the graph');
       }
-      this.pointers.add(pointer);
+      yield resolvedPointer;
     }
   }
 

--- a/packages/gbnf/src/grammar-parser/graph/graph.ts
+++ b/packages/gbnf/src/grammar-parser/graph/graph.ts
@@ -61,7 +61,7 @@ export class Graph {
     }
     this.pointers = pointers;
     return pointers;
-  }
+  };
 
   setValid(pointers: GraphPointer[], valid: boolean) {
     for (const pointer of pointers) {

--- a/packages/gbnf/src/grammar-parser/graph/types.ts
+++ b/packages/gbnf/src/grammar-parser/graph/types.ts
@@ -3,6 +3,7 @@ import type { PublicGraphPointer, } from "./graph-pointer.js";
 import type { RuleRef, } from "./rule-ref.js";
 
 export interface PrintOpts { pointers?: Set<PublicGraphPointer>; colorize: Colorize; showPosition: boolean };
+export type Pointers = Set<PublicGraphPointer>;
 
 export enum RuleType {
   CHAR = 'CHAR',


### PR DESCRIPTION
Set `rootNode` as property, pass in pointer, turn resolvePointer into an iterator function