### PR TITLE
Set up unique keys for pointers

### DIFF
--- a/packages/gbnf/src/gbnf.ts
+++ b/packages/gbnf/src/gbnf.ts
@@ -1,7 +1,7 @@
 import { buildRuleStack, } from "./grammar-parser/build-rule-stack.js";
 import { Graph, } from "./grammar-parser/graph/graph.js";
 import { ParseState, } from "./grammar-parser/graph/state.js";
-import { GraphRule, } from "./grammar-parser/graph/types.js";
+import { UnresolvedRule, } from "./grammar-parser/graph/types.js";
 import { RulesBuilder, } from "./rules-builder/rules-builder.js";
 
 export const GBNF = (grammar: string, initialString = ''): ParseState => {
@@ -14,7 +14,7 @@ export const GBNF = (grammar: string, initialString = ''): ParseState => {
   }
   const rootId = symbolIds.get('root');
 
-  const stackedRules: GraphRule[][][] = rules.map(buildRuleStack);
+  const stackedRules: UnresolvedRule[][][] = rules.map(buildRuleStack);
   const graph = new Graph(stackedRules, rootId);
   return new ParseState(graph, graph.add(initialString));
 };

--- a/packages/gbnf/src/grammar-parser/build-rule-stack.ts
+++ b/packages/gbnf/src/grammar-parser/build-rule-stack.ts
@@ -12,7 +12,7 @@ import {
 } from "../rules-builder/types.js";
 import { RuleRef, } from "./graph/rule-ref.js";
 import {
-  GraphRule,
+  UnresolvedRule,
   RuleChar,
   RuleCharExclude,
   RuleType,
@@ -27,10 +27,10 @@ function makeCharRule<R extends (InternalRuleDefChar | InternalRuleDefCharNot)>(
   } as R extends InternalRuleDefChar ? RuleChar : RuleCharExclude;
 }
 
-export const buildRuleStack = (linearRules: InternalRuleDef[]): GraphRule[][] => {
-  let paths: GraphRule[] = [];
+export const buildRuleStack = (linearRules: InternalRuleDef[]): UnresolvedRule[][] => {
+  let paths: UnresolvedRule[] = [];
 
-  const stack: GraphRule[][] = [];
+  const stack: UnresolvedRule[][] = [];
 
   let idx = 0;
   while (idx < linearRules.length) {

--- a/packages/gbnf/src/grammar-parser/graph/generic-set.ts
+++ b/packages/gbnf/src/grammar-parser/graph/generic-set.ts
@@ -27,6 +27,6 @@ export class GenericSet<T, K> {
   *[Symbol.iterator](): IterableIterator<T> {
     yield* this.#set;
   }
-}
 
-// export const GenericSet = Set;
+  get size() { return this.#set.size; }
+}

--- a/packages/gbnf/src/grammar-parser/graph/get-serialized-rule-key.ts
+++ b/packages/gbnf/src/grammar-parser/graph/get-serialized-rule-key.ts
@@ -1,6 +1,6 @@
-import { GraphRule, isGraphRule, isRuleChar, isRuleRef, } from "./types.js";
+import { UnresolvedRule, isGraphRule, isRuleChar, isRuleRef, } from "./types.js";
 
-export const getSerializedRuleKey = (rule: GraphRule) => {
+export const getSerializedRuleKey = (rule: UnresolvedRule) => {
   if (isGraphRule(rule)) {
     if (isRuleChar(rule)) {
       return `${rule.type}-${rule.value.join(',')}`;

--- a/packages/gbnf/src/grammar-parser/graph/graph.ts
+++ b/packages/gbnf/src/grammar-parser/graph/graph.ts
@@ -1,15 +1,14 @@
 // import { CustomInspectFunction, InspectOptions } from "util";
-import { GraphPointer, PublicGraphPointer, } from "./graph-pointer.js";
+import { GraphPointer, ResolvedGraphPointer, } from "./graph-pointer.js";
 import { GraphNode, } from "./graph-node.js";
 import { getSerializedRuleKey, } from "./get-serialized-rule-key.js";
 import { colorize, } from "./colorize.js";
 import { GenericSet, } from "./generic-set.js";
-import { GraphRule, Pointers, isRange, isRuleChar, isRuleCharExcluded, isRuleEnd, isRuleRef, } from "./types.js";
+import { UnresolvedRule, Pointers, customInspectSymbol, isRange, isRuleChar, isRuleCharExcluded, isRuleEnd, isRuleRef, } from "./types.js";
 import { isPointInRange, } from "../is-point-in-range.js";
 import { InputParseError, } from "../errors.js";
 import { RuleRef, } from "./rule-ref.js";
 
-const customInspectSymbol = Symbol.for('nodejs.util.inspect.custom');
 type RootNode = Map<number, GraphNode>;
 export class Graph {
   roots = new Map<number, RootNode>();
@@ -17,7 +16,7 @@ export class Graph {
   rootNode: RootNode;
   pointers: Pointers;
 
-  constructor(stackedRules: GraphRule[][][], rootId: number) {
+  constructor(stackedRules: UnresolvedRule[][][], rootId: number) {
     const ruleRefs: RuleRef[] = [];
     for (let stackId = 0; stackId < stackedRules.length; stackId++) {
       const stack = stackedRules[stackId];
@@ -96,7 +95,10 @@ export class Graph {
       }
     }
 
-    const nextPointers: Pointers = new Set();
+    // a pointer's id is the sum of its node's id and its parent's id chain.
+    // if two pointers share the same id, it means they point to the same node and have identical parent chains.
+    // for the purposes of walking the graph, we only need to keep one of them.
+    const nextPointers = new GenericSet<ResolvedGraphPointer, string>(p => p.id);
     for (const currentPointer of currentPointers) {
       for (const unresolvedNextPointer of currentPointer.fetchNext()) {
         for (const resolvedNextPointer of this.resolvePointer(unresolvedNextPointer)) {
@@ -107,7 +109,7 @@ export class Graph {
     return nextPointers;
   }
 
-  * resolvePointer(unresolvedPointer: GraphPointer): IterableIterator<PublicGraphPointer> {
+  * resolvePointer(unresolvedPointer: GraphPointer): IterableIterator<ResolvedGraphPointer> {
     for (const resolvedPointer of unresolvedPointer.resolve()) {
       if (isRuleRef(resolvedPointer.node.rule)) {
         throw new Error('Encountered a reference rule when building pointers to the graph');
@@ -163,8 +165,8 @@ export class Graph {
     return `\n${graphView.join('\n')}`;
   };
 
-  * iterateOverPointers(pointers: Pointers): IterableIterator<{ rule: GraphRule; rulePointers: GraphPointer[]; }> {
-    const seenRules = new Map<string, { rule: GraphRule; pointers: GraphPointer[]; }>();
+  * iterateOverPointers(pointers: Pointers): IterableIterator<{ rule: UnresolvedRule; rulePointers: GraphPointer[]; }> {
+    const seenRules = new Map<string, { rule: UnresolvedRule; pointers: GraphPointer[]; }>();
     const seen = new GenericSet<GraphNode, string>(pointer => getSerializedRuleKey(pointer.rule));
     for (const pointer of pointers) {
       const rule = pointer.rule;

--- a/packages/gbnf/src/grammar-parser/graph/graph.ts
+++ b/packages/gbnf/src/grammar-parser/graph/graph.ts
@@ -10,6 +10,7 @@ import { InputParseError, } from "../errors.js";
 import { RuleRef, } from "./rule-ref.js";
 
 type RootNode = Map<number, GraphNode>;
+const makePointers = () => new GenericSet<ResolvedGraphPointer, string>(p => p.id);
 export class Graph {
   roots = new Map<number, RootNode>();
   rootId: number;
@@ -49,7 +50,7 @@ export class Graph {
   }
 
   getInitialPointers = (): Pointers => {
-    const pointers: Pointers = new Set();
+    const pointers = makePointers();
 
     for (const { node, parent, } of this.fetchNodesForRootNode(this.rootNode)) {
       const pointer = new GraphPointer(node, parent);
@@ -98,7 +99,7 @@ export class Graph {
     // a pointer's id is the sum of its node's id and its parent's id chain.
     // if two pointers share the same id, it means they point to the same node and have identical parent chains.
     // for the purposes of walking the graph, we only need to keep one of them.
-    const nextPointers = new GenericSet<ResolvedGraphPointer, string>(p => p.id);
+    const nextPointers = makePointers();
     for (const currentPointer of currentPointers) {
       for (const unresolvedNextPointer of currentPointer.fetchNext()) {
         for (const resolvedNextPointer of this.resolvePointer(unresolvedNextPointer)) {

--- a/packages/gbnf/src/grammar-parser/graph/state.ts
+++ b/packages/gbnf/src/grammar-parser/graph/state.ts
@@ -1,5 +1,5 @@
 import type { Graph, } from "./graph.js";
-import type { Pointers, Rule, } from "./types.js";
+import type { Pointers, ResolvedRule, } from "./types.js";
 
 
 export class ParseState {
@@ -10,11 +10,11 @@ export class ParseState {
     this.#pointers = pointers;
   }
 
-  *[Symbol.iterator](): IterableIterator<Rule> {
+  *[Symbol.iterator](): IterableIterator<ResolvedRule> {
     yield* this.rules();
   }
 
-  *rules(): IterableIterator<Rule> {
+  *rules(): IterableIterator<ResolvedRule> {
     const seen = new Set<string>();
     for (const { rule, } of this.#pointers) {
       const key = JSON.stringify(rule);

--- a/packages/gbnf/src/grammar-parser/graph/types.ts
+++ b/packages/gbnf/src/grammar-parser/graph/types.ts
@@ -1,9 +1,11 @@
 import type { Colorize, } from "./colorize.js";
-import type { PublicGraphPointer, } from "./graph-pointer.js";
+import type { GenericSet, } from "./generic-set.js";
+import type { ResolvedGraphPointer, } from "./graph-pointer.js";
 import type { RuleRef, } from "./rule-ref.js";
 
-export interface PrintOpts { pointers?: Set<PublicGraphPointer>; colorize: Colorize; showPosition: boolean };
-export type Pointers = Set<PublicGraphPointer>;
+export const customInspectSymbol = Symbol.for('nodejs.util.inspect.custom');
+export type Pointers = GenericSet<ResolvedGraphPointer, string>;
+export interface PrintOpts { pointers?: Pointers; colorize: Colorize; showPosition: boolean };
 
 export enum RuleType {
   CHAR = 'CHAR',
@@ -26,17 +28,17 @@ export interface RuleCharExclude {
 export interface RuleEnd {
   type: RuleType.END;
 }
-export type GraphRule = RuleChar | RuleCharExclude | RuleRef | RuleEnd;
+export type UnresolvedRule = RuleChar | RuleCharExclude | RuleRef | RuleEnd;
 // RuleRefs should never be exposed to the end user.
-export type Rule = RuleCharExclude | RuleChar | RuleEnd;
-export type ReturnRuleValue = Rule;
+export type ResolvedRule = RuleCharExclude | RuleChar | RuleEnd;
+export type PublicRule = ResolvedRule;
 
 /** Type Guards */
-export const isGraphRule = (rule?: unknown): rule is GraphRule => !!rule && typeof rule === 'object' && 'type' in rule && isRuleType(rule.type);
+export const isGraphRule = (rule?: unknown): rule is UnresolvedRule => !!rule && typeof rule === 'object' && 'type' in rule && isRuleType(rule.type);
 export const isRuleType = (type?: unknown): type is RuleType => !!type && Object.values(RuleType).includes(type as RuleType);
-export const isRule = (rule?: unknown): rule is GraphRule => !!rule && typeof rule === 'object' && 'type' in rule && isRuleType(rule.type);
-export const isRuleRef = (rule?: GraphRule): rule is RuleRef => rule.type === RuleType.REF;
-export const isRuleEnd = (rule?: GraphRule): rule is RuleEnd => rule.type === RuleType.END;
-export const isRuleChar = (rule?: GraphRule): rule is RuleChar => rule.type === RuleType.CHAR;
-export const isRuleCharExcluded = (rule?: GraphRule): rule is RuleCharExclude => rule.type === RuleType.CHAR_EXCLUDE;
+export const isRule = (rule?: unknown): rule is UnresolvedRule => !!rule && typeof rule === 'object' && 'type' in rule && isRuleType(rule.type);
+export const isRuleRef = (rule?: UnresolvedRule): rule is RuleRef => rule.type === RuleType.REF;
+export const isRuleEnd = (rule?: UnresolvedRule): rule is RuleEnd => rule.type === RuleType.END;
+export const isRuleChar = (rule?: UnresolvedRule): rule is RuleChar => rule.type === RuleType.CHAR;
+export const isRuleCharExcluded = (rule?: UnresolvedRule): rule is RuleCharExclude => rule.type === RuleType.CHAR_EXCLUDE;
 export const isRange = (range?: unknown): range is Range => Array.isArray(range) && range.length === 2 && range.every(n => typeof n === 'number');

--- a/packages/gbnf/src/index.ts
+++ b/packages/gbnf/src/index.ts
@@ -2,7 +2,7 @@ export { GBNF as default, } from './gbnf.js';
 export {
   isRange,
   RuleType,
-  type ReturnRuleValue as Rule,
+  type PublicRule as Rule,
   type RuleCharExclude,
   type RuleChar,
   type RuleEnd,

--- a/packages/gbnf/test/additional-strings.test.ts
+++ b/packages/gbnf/test/additional-strings.test.ts
@@ -1,7 +1,7 @@
 import GBNF, { RuleType, } from '../src/index.js';
 
 describe('additional strings', () => {
-  test.only.each([
+  test.each([
     // single char rule
     ['root ::= "foo"', 'f', '1',],
     ['root ::= "foo"', 'f', 'b',],

--- a/packages/gbnf/test/additional-strings.test.ts
+++ b/packages/gbnf/test/additional-strings.test.ts
@@ -1,7 +1,7 @@
 import GBNF, { RuleType, } from '../src/index.js';
 
 describe('additional strings', () => {
-  test.each([
+  test.only.each([
     // single char rule
     ['root ::= "foo"', 'f', '1',],
     ['root ::= "foo"', 'f', 'b',],


### PR DESCRIPTION
This will ensure that the numbers of pointers does not unnecessarily grow over time, as duplicate pointers will be culled.