### PR TITLE
Keep copy of grammar

### DIFF
--- a/packages/gbnf/src/gbnf.ts
+++ b/packages/gbnf/src/gbnf.ts
@@ -1,6 +1,6 @@
 import { buildRuleStack, } from "./grammar-parser/build-rule-stack.js";
 import { Graph, } from "./grammar-parser/graph/graph.js";
-import { ParseState, } from "./grammar-parser/graph/state.js";
+import { ParseState, } from "./grammar-parser/graph/parse-state.js";
 import { UnresolvedRule, ValidInput, } from "./grammar-parser/graph/types.js";
 import { RulesBuilder, } from "./rules-builder/rules-builder.js";
 
@@ -15,6 +15,6 @@ export const GBNF = (grammar: string, initialString: ValidInput = ''): ParseStat
   const rootId = symbolIds.get('root');
 
   const stackedRules: UnresolvedRule[][][] = rules.map(buildRuleStack);
-  const graph = new Graph(stackedRules, rootId);
+  const graph = new Graph(grammar, stackedRules, rootId);
   return new ParseState(graph, graph.add(initialString));
 };

--- a/packages/gbnf/src/grammar-parser/graph/graph.ts
+++ b/packages/gbnf/src/grammar-parser/graph/graph.ts
@@ -17,8 +17,10 @@ export class Graph {
   rootId: number;
   rootNode: RootNode;
   pointers: Pointers;
+  grammar: string;
 
-  constructor(stackedRules: UnresolvedRule[][][], rootId: number) {
+  constructor(grammar: string, stackedRules: UnresolvedRule[][][], rootId: number) {
+    this.grammar = grammar;
     const ruleRefs: RuleRef[] = [];
     const uniqueRules = new GenericSet<UnresolvedRule, string>(rule => getSerializedRuleKey(rule));
     for (let stackId = 0; stackId < stackedRules.length; stackId++) {

--- a/packages/gbnf/src/grammar-parser/graph/parse-state.ts
+++ b/packages/gbnf/src/grammar-parser/graph/parse-state.ts
@@ -33,4 +33,8 @@ export class ParseState {
   size() {
     return Array.from(this.rules()).length;
   }
+
+  get grammar() {
+    return this.#graph.grammar;
+  }
 }

--- a/packages/gbnf/src/grammar-parser/graph/types.ts
+++ b/packages/gbnf/src/grammar-parser/graph/types.ts
@@ -10,6 +10,10 @@ export interface PrintOpts { pointers?: Pointers; colorize: Colorize; showPositi
 export enum RuleType {
   CHAR = 'char',
   CHAR_EXCLUDE = 'char_exclude',
+<<<<<<< HEAD
+=======
+  REF = 'ref',
+>>>>>>> 92f72a8 (Update type exports)
   END = 'end',
 }
 

--- a/packages/gbnf/src/grammar-parser/graph/types.ts
+++ b/packages/gbnf/src/grammar-parser/graph/types.ts
@@ -10,10 +10,6 @@ export interface PrintOpts { pointers?: Pointers; colorize: Colorize; showPositi
 export enum RuleType {
   CHAR = 'char',
   CHAR_EXCLUDE = 'char_exclude',
-<<<<<<< HEAD
-=======
-  REF = 'ref',
->>>>>>> 92f72a8 (Update type exports)
   END = 'end',
 }
 

--- a/packages/gbnf/src/index.ts
+++ b/packages/gbnf/src/index.ts
@@ -8,4 +8,4 @@ export {
   type RuleEnd,
   type Range,
 } from './grammar-parser/graph/types.js';
-export { ParseState, } from './grammar-parser/graph/state.js';
+export { ParseState, } from './grammar-parser/graph/parse-state.js';


### PR DESCRIPTION
Expose a copy of the grammar on each instance of a `ParseState`